### PR TITLE
ci: 🎡 jenkins 배포용으로 환경변수 추가

### DIFF
--- a/src/main/resources/application-prod2.properties
+++ b/src/main/resources/application-prod2.properties
@@ -1,0 +1,27 @@
+server.port=7778
+#cookshoong.skm.keyid.mysql=217e810e661e4e80b1a4b6943e62215c
+
+spring.application.name=AUTH
+
+management.endpoint.shutdown.enabled=true
+management.info.env.enabled=true
+management.endpoint.health.status.order=DOWN, UP
+management.endpoints.web.exposure.include=health, info
+
+info.cookshoong.auth.author.name=koesnam
+
+server.shutdown=graceful
+spring.lifecycle.timeout-per-shutdown-phase=10s
+
+#eureka.client.service-url.defaultZone=http://admin:1234@180.210.82.97:8761/eureka
+eureka.client.register-with-eureka=true
+eureka.client.fetch-registry=true
+eureka.client.registry-fetch-interval-seconds=30
+eureka.client.disable-delta=true
+
+eureka.instance.lease-renewal-interval-in-seconds=3
+eureka.instance.lease-expiration-duration-in-seconds=10
+eureka.instance.prefer-ip-address=true
+
+#spring.cloud.inetutils.ignored-interfaces=eth1*
+#spring.cloud.inetutils.preferred-networks=192.168


### PR DESCRIPTION
인스턴스에서 도커를 7778:7777로 했을 때 빌드 단계에서 멈춰버림.
7778 포트를 가지는 서버로 열리게 설정.