### PR TITLE
ci: 🎡 추가 시큐리티 설정

### DIFF
--- a/src/main/java/store/cookshoong/www/cookshoongauth/config/SecurityConfig.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package store.cookshoong.www.cookshoongauth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * {설명을 작성해주세요}
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.12
+ */
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests()
+            .anyRequest()
+            .permitAll();
+
+        http.csrf()
+            .disable();
+
+        return http.build();
+    }
+
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,1 +1,0 @@
-#eureka.client.service-url.defaultZone=http://admin:1234@localhost:8761/eureka

--- a/src/main/resources/application-prod2.properties
+++ b/src/main/resources/application-prod2.properties
@@ -22,5 +22,5 @@ eureka.instance.lease-renewal-interval-in-seconds=3
 eureka.instance.lease-expiration-duration-in-seconds=10
 eureka.instance.prefer-ip-address=true
 eureka.instance.ip-address=133.186.152.236
-eureka.instance.instance-id=cookshoong-auth:7777
+eureka.instance.instance-id=cookshoong-auth:7778
 eureka.instance.hostname=cookshoong-auth

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,8 @@ server.port=7777
 #spring.datasource.dbcp2.test-on-return=true
 #spring.datasource.dbcp2.test-while-idle=true
 
+management.info.env.enabled=true
+management.endpoint.health.status.order=DOWN, UP
+management.endpoints.web.exposure.include=health, info
+
+info.cookshoong.auth.author.name=koesnam


### PR DESCRIPTION
서버 상태를 변경하는 엔드 포인트 호출이 안되는 이슈 해결
-> Security 설정이 안되어있어서 endpoint로 접근이 불가능 했었음 = 서버 상태 변경 불가능 --> Security 설정을 통해 엔드포인트를 열어줌

Eureka에서 auth 서버가 한대로 잡히는 이슈 해결
-> 두 컨테이너를 하나의 prod.properties로 관리하려고 했는데 그렇다 보니 eureak-instance-id가 겹침 = eureka에선 하나의 서버로 인식 --> profile을 prod, prod2로 나눠서 설정