### PR TITLE
Jwt 발행 기능

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,36 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
+        <!-- json 생성과 구문 분석을 위한 종속성-->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- 자바 10 이상에 필요한 종속성 -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>4.0.2</version>
+        </dependency>
 
-<!--        <dependency>-->
-<!--            <groupId>com.mysql</groupId>-->
-<!--            <artifactId>mysql-connector-j</artifactId>-->
-<!--            <scope>runtime</scope>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>

--- a/src/main/java/store/cookshoong/www/cookshoongauth/CookshoongAuthApplication.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/CookshoongAuthApplication.java
@@ -7,6 +7,12 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration;
 import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClientConfiguration;
 
+/**
+ * 애플리케이션 엔트리포인트.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.03
+ */
 @ConfigurationPropertiesScan
 @EnableDiscoveryClient
 @SpringBootApplication(exclude = {EurekaClientAutoConfiguration.class, EurekaDiscoveryClientConfiguration.class})

--- a/src/main/java/store/cookshoong/www/cookshoongauth/CookshoongAuthApplication.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/CookshoongAuthApplication.java
@@ -2,10 +2,14 @@ package store.cookshoong.www.cookshoongauth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration;
+import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClientConfiguration;
 
+@ConfigurationPropertiesScan
 @EnableDiscoveryClient
-@SpringBootApplication
+@SpringBootApplication(exclude = {EurekaClientAutoConfiguration.class, EurekaDiscoveryClientConfiguration.class})
 public class CookshoongAuthApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/store/cookshoong/www/cookshoongauth/adapter/ApiAdapter.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/adapter/ApiAdapter.java
@@ -1,0 +1,37 @@
+package store.cookshoong.www.cookshoongauth.adapter;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import store.cookshoong.www.cookshoongauth.model.request.LoginRequestDto;
+import store.cookshoong.www.cookshoongauth.model.response.AuthenticationResponseDto;
+import store.cookshoong.www.cookshoongauth.property.ApiProperties;
+
+/**
+ * Resource Server(Backend server)로 부터 인증 정보를 가져오기 위한 어댑터.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.15
+ */
+@Component
+@RequiredArgsConstructor
+public class ApiAdapter {
+    private final RestTemplate restTemplate;
+    private final ApiProperties apiProperties;
+
+    public AuthenticationResponseDto fetchCredential(LoginRequestDto loginRequestDto) {
+        URI uri = UriComponentsBuilder.fromUriString(apiProperties.getGatewayUri())
+            .pathSegment("api")
+            .pathSegment("accounts")
+            .pathSegment("{loginId}")
+            .path("auth")
+            .buildAndExpand(loginRequestDto.getLoginId())
+            .toUri();
+
+        return restTemplate.getForEntity(uri, AuthenticationResponseDto.class)
+            .getBody();
+    }
+
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/adapter/ApiAdapter.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/adapter/ApiAdapter.java
@@ -21,6 +21,12 @@ public class ApiAdapter {
     private final RestTemplate restTemplate;
     private final ApiProperties apiProperties;
 
+    /**
+     * 자격증명정보를 백엔드 서버에 호출한다.
+     *
+     * @param loginRequestDto the login request dto
+     * @return the authentication response dto
+     */
     public AuthenticationResponseDto fetchCredential(LoginRequestDto loginRequestDto) {
         URI uri = UriComponentsBuilder.fromUriString(apiProperties.getGatewayUri())
             .pathSegment("api")

--- a/src/main/java/store/cookshoong/www/cookshoongauth/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/advice/ControllerExceptionAdvice.java
@@ -1,0 +1,21 @@
+package store.cookshoong.www.cookshoongauth.advice;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.client.HttpClientErrorException;
+
+/**
+ * 인증과정에서 예외(회원 조회 실패, 비밀번호 검증실패)를 처리하는 클래스.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.13
+ */
+@ControllerAdvice
+public class ControllerExceptionAdvice {
+    @ExceptionHandler(HttpClientErrorException.class)
+    public ResponseEntity<Void> notfound() {
+        return ResponseEntity.notFound()
+            .build();
+    }
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/advice/ControllerExceptionAdvice.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.HttpClientErrorException;
+import store.cookshoong.www.cookshoongauth.exeption.LoginValidationException;
 
 /**
  * 인증과정에서 예외(회원 조회 실패, 비밀번호 검증실패)를 처리하는 클래스.
@@ -16,6 +17,12 @@ public class ControllerExceptionAdvice {
     @ExceptionHandler(HttpClientErrorException.class)
     public ResponseEntity<Void> notfound() {
         return ResponseEntity.notFound()
+            .build();
+    }
+
+    @ExceptionHandler(LoginValidationException.class)
+    public ResponseEntity<Void> badRequest() {
+        return ResponseEntity.badRequest()
             .build();
     }
 }

--- a/src/main/java/store/cookshoong/www/cookshoongauth/config/RestTemplateConfig.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/config/RestTemplateConfig.java
@@ -1,0 +1,23 @@
+package store.cookshoong.www.cookshoongauth.config;
+
+import java.time.Duration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * API 를 호출하기 위한 RestTemplate 에 대한 설정클래스.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.13
+ */
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplateBuilder().setConnectTimeout(Duration.ofSeconds(10))
+            .setReadTimeout(Duration.ofSeconds(10))
+            .build();
+    }
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/config/RestTemplateConfig.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/config/RestTemplateConfig.java
@@ -14,6 +14,11 @@ import org.springframework.web.client.RestTemplate;
  */
 @Configuration
 public class RestTemplateConfig {
+    /**
+     * 기본 RestTemplate 을 Bean 으로 등록한다.
+     *
+     * @return the rest template
+     */
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplateBuilder().setConnectTimeout(Duration.ofSeconds(10))

--- a/src/main/java/store/cookshoong/www/cookshoongauth/config/SecurityConfig.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/config/SecurityConfig.java
@@ -1,20 +1,27 @@
 package store.cookshoong.www.cookshoongauth.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
- * {설명을 작성해주세요}
+ * 시큐리티 관련 설정 클래스.
  *
  * @author koesnam (추만석)
  * @since 2023.07.12
  */
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.formLogin()
+            .disable();
+
         http.authorizeHttpRequests()
             .anyRequest()
             .permitAll();
@@ -25,4 +32,8 @@ public class SecurityConfig {
         return http.build();
     }
 
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/src/main/java/store/cookshoong/www/cookshoongauth/config/SecurityConfig.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/config/SecurityConfig.java
@@ -17,6 +17,13 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    /**
+     * 시큐리티 필터 설정.
+     *
+     * @param http the http
+     * @return the security filter chain
+     * @throws Exception the exception
+     */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.formLogin()

--- a/src/main/java/store/cookshoong/www/cookshoongauth/controller/AuthController.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpClientErrorException;
 import store.cookshoong.www.cookshoongauth.model.request.LoginRequestDto;
 import store.cookshoong.www.cookshoongauth.model.response.LoginSuccessResponseDto;
 import store.cookshoong.www.cookshoongauth.model.vo.AccountInfo;
@@ -25,7 +26,8 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<LoginSuccessResponseDto> login(@RequestBody LoginRequestDto loginRequestDto) {
+    public ResponseEntity<LoginSuccessResponseDto> login(@RequestBody LoginRequestDto loginRequestDto)
+        throws HttpClientErrorException {
         AccountInfo accountInfo = authService.executeAuthentication(loginRequestDto);
         return ResponseEntity.ok(authService.issueTokens(accountInfo));
     }

--- a/src/main/java/store/cookshoong/www/cookshoongauth/controller/AuthController.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/controller/AuthController.java
@@ -1,0 +1,32 @@
+package store.cookshoong.www.cookshoongauth.controller;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import store.cookshoong.www.cookshoongauth.model.request.LoginRequestDto;
+import store.cookshoong.www.cookshoongauth.model.response.LoginSuccessResponseDto;
+import store.cookshoong.www.cookshoongauth.model.vo.AccountInfo;
+import store.cookshoong.www.cookshoongauth.service.AuthService;
+
+/**
+ * 인증처리에 대한 엔드포인트.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.13
+ */
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginSuccessResponseDto> login(@RequestBody LoginRequestDto loginRequestDto) {
+        AccountInfo accountInfo = authService.executeAuthentication(loginRequestDto);
+        return ResponseEntity.ok(authService.issueTokens(accountInfo));
+    }
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/controller/AuthController.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/controller/AuthController.java
@@ -1,13 +1,15 @@
 package store.cookshoong.www.cookshoongauth.controller;
 
-import java.util.UUID;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
+import store.cookshoong.www.cookshoongauth.exeption.LoginValidationException;
 import store.cookshoong.www.cookshoongauth.model.request.LoginRequestDto;
 import store.cookshoong.www.cookshoongauth.model.response.LoginSuccessResponseDto;
 import store.cookshoong.www.cookshoongauth.model.vo.AccountInfo;
@@ -25,9 +27,22 @@ import store.cookshoong.www.cookshoongauth.service.AuthService;
 public class AuthController {
     private final AuthService authService;
 
+    /**
+     * 로그인 처리에 대한 엔드포인트.
+     *
+     * @param loginRequestDto the login request dto
+     * @param bindingResult   the binding result
+     * @return the response entity
+     * @throws HttpClientErrorException the http client error exception
+     */
     @PostMapping("/login")
-    public ResponseEntity<LoginSuccessResponseDto> login(@RequestBody LoginRequestDto loginRequestDto)
+    public ResponseEntity<LoginSuccessResponseDto> login(@Valid @RequestBody LoginRequestDto loginRequestDto,
+                                                         BindingResult bindingResult)
         throws HttpClientErrorException {
+        if (bindingResult.hasErrors()) {
+            throw new LoginValidationException();
+        }
+
         AccountInfo accountInfo = authService.executeAuthentication(loginRequestDto);
         return ResponseEntity.ok(authService.issueTokens(accountInfo));
     }

--- a/src/main/java/store/cookshoong/www/cookshoongauth/controller/HealthController.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/controller/HealthController.java
@@ -3,6 +3,7 @@ package store.cookshoong.www.cookshoongauth.controller;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.InstanceInfo;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author koesnam (추만석)
  * @since 2023.07.11
  */
+@Profile("prod | prod2")
 @RestController
 @RequiredArgsConstructor
 public class HealthController {

--- a/src/main/java/store/cookshoong/www/cookshoongauth/controller/HealthController.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/controller/HealthController.java
@@ -20,6 +20,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class HealthController {
     private final ApplicationInfoManager applicationInfoManager;
+
+    /**
+     * 서버 상태를 DOWN 으로 바꾸는 메서드.
+     *
+     * @return the response entity
+     */
     @PostMapping("/health-check/fail")
     public ResponseEntity<Void> stop() {
         applicationInfoManager.setInstanceStatus(InstanceInfo.InstanceStatus.DOWN);
@@ -27,6 +33,11 @@ public class HealthController {
             .build();
     }
 
+    /**
+     * 서버 상태를 UP 으로 바꾸는 메서드.
+     *
+     * @return the response entity
+     */
     @PostMapping("/health-check/recover")
     public ResponseEntity<Void> start() {
         applicationInfoManager.setInstanceStatus(InstanceInfo.InstanceStatus.UP);
@@ -34,6 +45,11 @@ public class HealthController {
             .build();
     }
 
+    /**
+     * 현재 서버 상태를 확인하는 메서드.
+     *
+     * @return the response entity
+     */
     @GetMapping("/health-check")
     public ResponseEntity<InstanceInfo.InstanceStatus> check() {
         return ResponseEntity.ok(applicationInfoManager

--- a/src/main/java/store/cookshoong/www/cookshoongauth/exeption/LoginValidationException.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/exeption/LoginValidationException.java
@@ -1,0 +1,13 @@
+package store.cookshoong.www.cookshoongauth.exeption;
+
+/**
+ * 아이디나 비밀번호에 빈 값이 들어온 경우에 일어나는 예외.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.15
+ */
+public class LoginValidationException extends RuntimeException {
+    public LoginValidationException() {
+        super("아이디 또는 비밀번호를 확인해주세요.");
+    }
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JsonWebTokenProvider.java
@@ -20,13 +20,13 @@ public class JsonWebTokenProvider {
     /**
      * 토큰 식별자와 회원의 권한을 담은 액세스 토큰을 만든다.
      *
-     * @param jid       the jid
+     * @param jti       the jti
      * @param authority the authority
      * @return the string
      */
-    public String createAccessToken(String jid, String authority) {
+    public String createAccessToken(String jti, String authority) {
         Map<String, Object> payloads = new HashMap<>();
-        payloads.put("jid", jid);
+        payloads.put("jti", jti);
         payloads.put("authority", authority);
         return createAccessToken(payloads);
     }
@@ -38,15 +38,15 @@ public class JsonWebTokenProvider {
     /**
      * 토큰 식별자와 회원 시퀀스, 회원 상태, 회원의 아이디를 담은 액세스 토큰을 만든다.
      *
-     * @param jid       the jid
+     * @param jti       the jti
      * @param accountId the account id
      * @param status    the status
      * @param loginId   the login id
      * @return the string
      */
-    public String createRefreshToken(String jid, String accountId, String status, String loginId) {
+    public String createRefreshToken(String jti, String accountId, String status, String loginId) {
         Map<String, Object> payloads = new HashMap<>();
-        payloads.put("jid", jid);
+        payloads.put("jti", jti);
         payloads.put("accountId", accountId);
         payloads.put("status", status);
         payloads.put("loginId", loginId);

--- a/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JsonWebTokenProvider.java
@@ -17,6 +17,13 @@ import store.cookshoong.www.cookshoongauth.util.JwtFactory;
 public class JsonWebTokenProvider {
     private final JwtProperties jwtProperties;
 
+    /**
+     * 토큰 식별자와 회원의 권한을 담은 액세스 토큰을 만든다.
+     *
+     * @param jid       the jid
+     * @param authority the authority
+     * @return the string
+     */
     public String createAccessToken(String jid, String authority) {
         Map<String, Object> payloads = new HashMap<>();
         payloads.put("jid", jid);
@@ -24,6 +31,19 @@ public class JsonWebTokenProvider {
         return createAccessToken(payloads);
     }
 
+    private String createAccessToken(Map<String, Object> payloads) {
+        return JwtFactory.createToken(Map.of(), payloads, jwtProperties.getSecret(), jwtProperties.getAccessTokenTtl());
+    }
+
+    /**
+     * 토큰 식별자와 회원 시퀀스, 회원 상태, 회원의 아이디를 담은 액세스 토큰을 만든다.
+     *
+     * @param jid       the jid
+     * @param accountId the account id
+     * @param status    the status
+     * @param loginId   the login id
+     * @return the string
+     */
     public String createRefreshToken(String jid, String accountId, String status, String loginId) {
         Map<String, Object> payloads = new HashMap<>();
         payloads.put("jid", jid);
@@ -33,10 +53,8 @@ public class JsonWebTokenProvider {
         return createRefreshToken(payloads);
     }
 
-    private String createAccessToken(Map<String, Object> payloads) {
-        return JwtFactory.createToken(Map.of(), payloads, jwtProperties.getSecret(), jwtProperties.getAccessTokenTtl());
-    }
     private String createRefreshToken(Map<String, Object> payloads) {
-        return JwtFactory.createToken(Map.of(), payloads, jwtProperties.getSecret(), jwtProperties.getRefreshTokenTtl());
+        return JwtFactory.createToken(Map.of(), payloads, jwtProperties.getSecret(),
+            jwtProperties.getRefreshTokenTtl());
     }
 }

--- a/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JsonWebTokenProvider.java
@@ -1,0 +1,42 @@
+package store.cookshoong.www.cookshoongauth.jwt;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import store.cookshoong.www.cookshoongauth.util.JwtFactory;
+
+/**
+ * 특정 정보를 받아 JWT(Json Web Token)을 만들어주는 클래스.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.14
+ */
+@Component
+@RequiredArgsConstructor
+public class JsonWebTokenProvider {
+    private final JwtProperties jwtProperties;
+
+    public String createAccessToken(String jid, String authority) {
+        Map<String, Object> payloads = new HashMap<>();
+        payloads.put("jid", jid);
+        payloads.put("authority", authority);
+        return createAccessToken(payloads);
+    }
+
+    public String createRefreshToken(String jid, String accountId, String status, String loginId) {
+        Map<String, Object> payloads = new HashMap<>();
+        payloads.put("jid", jid);
+        payloads.put("accountId", accountId);
+        payloads.put("status", status);
+        payloads.put("loginId", loginId);
+        return createRefreshToken(payloads);
+    }
+
+    private String createAccessToken(Map<String, Object> payloads) {
+        return JwtFactory.createToken(Map.of(), payloads, jwtProperties.getSecret(), jwtProperties.getAccessTokenTtl());
+    }
+    private String createRefreshToken(Map<String, Object> payloads) {
+        return JwtFactory.createToken(Map.of(), payloads, jwtProperties.getSecret(), jwtProperties.getRefreshTokenTtl());
+    }
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JwtConfig.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JwtConfig.java
@@ -1,0 +1,15 @@
+package store.cookshoong.www.cookshoongauth.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Jwt 관련 설정값을 가져오기 위한 클래스.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.14
+ */
+@Configuration
+@ConfigurationPropertiesScan(basePackageClasses = JwtConfig.class)
+public class JwtConfig {
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JwtProperties.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JwtProperties.java
@@ -1,0 +1,22 @@
+package store.cookshoong.www.cookshoongauth.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Jwt 관련 설정값들을 담고 있는 클래스
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.14
+ */
+@Getter
+@Setter
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+    // TODO: secret을 SKM에 올리기.
+    private String secret;
+    private String refreshSecret;
+    private Integer accessTokenTtl;
+    private Integer refreshTokenTtl;
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JwtProperties.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JwtProperties.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * Jwt 관련 설정값들을 담고 있는 클래스
+ * Jwt 관련 설정값들을 담고 있는 클래스.
  *
  * @author koesnam (추만석)
  * @since 2023.07.14

--- a/src/main/java/store/cookshoong/www/cookshoongauth/model/request/LoginRequestDto.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/model/request/LoginRequestDto.java
@@ -1,5 +1,6 @@
 package store.cookshoong.www.cookshoongauth.model.request;
 
+import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LoginRequestDto {
+    @NotBlank
     private String loginId;
+    @NotBlank
     private String password;
 }

--- a/src/main/java/store/cookshoong/www/cookshoongauth/model/request/LoginRequestDto.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/model/request/LoginRequestDto.java
@@ -1,0 +1,18 @@
+package store.cookshoong.www.cookshoongauth.model.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Front-server 에서 들어오는 로그인을 위한 자격증명정보.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.13
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginRequestDto {
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/model/response/AuthenticationResponseDto.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/model/response/AuthenticationResponseDto.java
@@ -1,0 +1,21 @@
+package store.cookshoong.www.cookshoongauth.model.response;
+
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * API(Backend-server) 를 통해 가져온 회원정보.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.13
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthenticationResponseDto {
+    private String loginId;
+    private String password;
+    private Map<String, Object> attributes;
+}
+

--- a/src/main/java/store/cookshoong/www/cookshoongauth/model/response/LoginSuccessResponseDto.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/model/response/LoginSuccessResponseDto.java
@@ -1,0 +1,18 @@
+package store.cookshoong.www.cookshoongauth.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 인증성공시 Front-server 로 보내줄 정보.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.15
+ */
+
+@Getter
+@AllArgsConstructor
+public class LoginSuccessResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/model/vo/AccountInfo.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/model/vo/AccountInfo.java
@@ -1,0 +1,25 @@
+package store.cookshoong.www.cookshoongauth.model.vo;
+
+import lombok.Getter;
+import store.cookshoong.www.cookshoongauth.model.response.AuthenticationResponseDto;
+
+/**
+ * 인증된 정보로부터 회원정보를 얻어내는 클래스. 현재 토큰 발급에 사용되고 있다.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.15
+ */
+@Getter
+public class AccountInfo {
+    private final String accountId;
+    private final String loginId;
+    private final String authority;
+    private final String status;
+
+    public AccountInfo(AuthenticationResponseDto dto) {
+        this.accountId = String.valueOf(dto.getAttributes().get("accountId")) ;
+        this.loginId = dto.getLoginId();
+        this.authority = (String) dto.getAttributes().get("authority");
+        this.status = (String) dto.getAttributes().get("status");
+    }
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/model/vo/AccountInfo.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/model/vo/AccountInfo.java
@@ -16,8 +16,13 @@ public class AccountInfo {
     private final String authority;
     private final String status;
 
+    /**
+     * 인증조회정보를 기반으로 회원정보 생성.
+     *
+     * @param dto the dto
+     */
     public AccountInfo(AuthenticationResponseDto dto) {
-        this.accountId = String.valueOf(dto.getAttributes().get("accountId")) ;
+        this.accountId = String.valueOf(dto.getAttributes().get("accountId"));
         this.loginId = dto.getLoginId();
         this.authority = (String) dto.getAttributes().get("authority");
         this.status = (String) dto.getAttributes().get("status");

--- a/src/main/java/store/cookshoong/www/cookshoongauth/property/ApiProperties.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/property/ApiProperties.java
@@ -1,0 +1,18 @@
+package store.cookshoong.www.cookshoongauth.property;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * API 를 호출할 주소를 담고 있는 클래스.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.15
+ */
+@Getter
+@Setter
+@ConfigurationProperties("api")
+public class ApiProperties {
+    private String gatewayUri;
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/service/AuthService.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/service/AuthService.java
@@ -54,15 +54,15 @@ public class AuthService {
         String status = accountInfo.getStatus();
         String accountId = accountInfo.getAccountId();
 
-        String jid = UUID.randomUUID().toString();
-        String accessToken = jwtProvider.createAccessToken(jid, authority);
-        String refreshToken = jwtProvider.createRefreshToken(jid, accountId, status, loginId);
+        String jti = UUID.randomUUID().toString();
+        String accessToken = jwtProvider.createAccessToken(jti, authority);
+        String refreshToken = jwtProvider.createRefreshToken(jti, accountId, status, loginId);
 
-        saveRefreshToken(jid, refreshToken);
+        saveRefreshToken(jti, refreshToken);
         return new LoginSuccessResponseDto(accessToken, refreshToken);
     }
 
-    public void saveRefreshToken(String jid, String refreshToken) {
+    public void saveRefreshToken(String jti, String refreshToken) {
         // TODO: redis에 RefreshToken 저장.
     }
 }

--- a/src/main/java/store/cookshoong/www/cookshoongauth/service/AuthService.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/service/AuthService.java
@@ -26,6 +26,12 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JsonWebTokenProvider jwtProvider;
 
+    /**
+     * 인증 처리하는 메서드.
+     *
+     * @param loginRequestDto the login request dto
+     * @return the account info
+     */
     public AccountInfo executeAuthentication(LoginRequestDto loginRequestDto) {
         AuthenticationResponseDto credential = apiAdapter.fetchCredential(loginRequestDto);
 
@@ -36,6 +42,12 @@ public class AuthService {
         return new AccountInfo(credential);
     }
 
+    /**
+     * 토큰(액세스, 리프레쉬)에 회원정보를 담아서 발행해주는 메서드.
+     *
+     * @param accountInfo the account info
+     * @return the login success response dto
+     */
     public LoginSuccessResponseDto issueTokens(AccountInfo accountInfo) {
         String loginId = accountInfo.getLoginId();
         String authority = accountInfo.getAuthority();

--- a/src/main/java/store/cookshoong/www/cookshoongauth/service/AuthService.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/service/AuthService.java
@@ -1,0 +1,56 @@
+package store.cookshoong.www.cookshoongauth.service;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import store.cookshoong.www.cookshoongauth.adapter.ApiAdapter;
+import store.cookshoong.www.cookshoongauth.jwt.JsonWebTokenProvider;
+import store.cookshoong.www.cookshoongauth.model.request.LoginRequestDto;
+import store.cookshoong.www.cookshoongauth.model.response.AuthenticationResponseDto;
+import store.cookshoong.www.cookshoongauth.model.response.LoginSuccessResponseDto;
+import store.cookshoong.www.cookshoongauth.model.vo.AccountInfo;
+
+/**
+ * 인증처리를 목적으로 하는 클래스.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.14
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final ApiAdapter apiAdapter;
+    private final PasswordEncoder passwordEncoder;
+    private final JsonWebTokenProvider jwtProvider;
+
+    public AccountInfo executeAuthentication(LoginRequestDto loginRequestDto) {
+        AuthenticationResponseDto credential = apiAdapter.fetchCredential(loginRequestDto);
+
+        if (!passwordEncoder.matches(loginRequestDto.getPassword(), credential.getPassword())) {
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND);
+        }
+
+        return new AccountInfo(credential);
+    }
+
+    public LoginSuccessResponseDto issueTokens(AccountInfo accountInfo) {
+        String loginId = accountInfo.getLoginId();
+        String authority = accountInfo.getAuthority();
+        String status = accountInfo.getStatus();
+        String accountId = accountInfo.getAccountId();
+
+        String jid = UUID.randomUUID().toString();
+        String accessToken = jwtProvider.createAccessToken(jid, authority);
+        String refreshToken = jwtProvider.createRefreshToken(jid, accountId, status, loginId);
+
+        saveRefreshToken(jid, refreshToken);
+        return new LoginSuccessResponseDto(accessToken, refreshToken);
+    }
+
+    public void saveRefreshToken(String jid, String refreshToken) {
+        // TODO: redis에 RefreshToken 저장.
+    }
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/util/JwtFactory.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/util/JwtFactory.java
@@ -18,7 +18,17 @@ import javax.crypto.SecretKey;
 public class JwtFactory {
     private JwtFactory() {}
 
-    public static String createToken(Map<String, Object> headers, Map<String, Object> payloads, String secret, int ttl) {
+    /**
+     * Jwt 토큰을 발행하는 메서드.
+     *
+     * @param headers  the headers
+     * @param payloads the payloads
+     * @param secret   the secret
+     * @param ttl      the ttl
+     * @return the string
+     */
+    public static String createToken(Map<String, Object> headers, Map<String, Object> payloads, String secret,
+                                     int ttl) {
         SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
 
         Date expireTime = new Date();

--- a/src/main/java/store/cookshoong/www/cookshoongauth/util/JwtFactory.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/util/JwtFactory.java
@@ -1,0 +1,34 @@
+package store.cookshoong.www.cookshoongauth.util;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
+
+/**
+ * Jwt 를 생성만을 담당하는 유틸클래스.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.14
+ */
+public class JwtFactory {
+    private JwtFactory() {}
+
+    public static String createToken(Map<String, Object> headers, Map<String, Object> payloads, String secret, int ttl) {
+        SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+
+        Date expireTime = new Date();
+        expireTime.setTime(expireTime.getTime() + ttl);
+
+        return Jwts.builder()
+            .setHeader(headers)
+            .setClaims(payloads)
+            .setExpiration(expireTime)
+            .signWith(key)
+            .compact();
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+api.gateway-uri=http://localhost:8080

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,5 +1,3 @@
-#cookshoong.skm.keyid.mysql=217e810e661e4e80b1a4b6943e62215c
-
 spring.application.name=AUTH
 
 management.endpoint.shutdown.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,26 +1,14 @@
 server.port=7777
 
-#spring.jpa.show-sql=true
-#spring.jpa.properties.hibernate.format_sql=true
-#spring.jpa.properties.hibernate.use_sql_comments=true
-#spring.jpa.properties.hibernate.highlight_sql=true
-#logging.level.org.hibernate.type.descriptor.sql=trace
-
-#cookshoong.skm.password=${SECURE_KEY_MANAGER_PASSWORD}
-#cookshoong.skm.appkey=${SECURE_KEY_MANAGER_APP_KEY}
-
-#spring.datasource.dbcp2.initial-size=10
-#spring.datasource.dbcp2.max-total=10
-#spring.datasource.dbcp2.min-idle=10
-#spring.datasource.dbcp2.max-idle=10
-#spring.datasource.dbcp2.max-wait-millis=1000
-#spring.datasource.dbcp2.validation-query=SELECT 1
-#spring.datasource.dbcp2.test-on-borrow=true
-#spring.datasource.dbcp2.test-on-return=true
-#spring.datasource.dbcp2.test-while-idle=true
-
 management.info.env.enabled=true
 management.endpoint.health.status.order=DOWN, UP
 management.endpoints.web.exposure.include=health, info
 
 info.cookshoong.auth.author.name=koesnam
+
+jwt.secret=TempTokenSecretMustBeLargerThan256Bit
+jwt.refresh-secret=TempRefreshTokenMustBeLargerThan256Bit
+jwt.access-token-TTL=30
+jwt.refresh-token-TTL=90
+
+api.gateway-uri=http://localhost:8080

--- a/src/test/java/store/cookshoong/www/cookshoongauth/controller/AuthControllerTest.java
+++ b/src/test/java/store/cookshoong/www/cookshoongauth/controller/AuthControllerTest.java
@@ -94,6 +94,7 @@ class AuthControllerTest {
     @DisplayName("로그인 - 검증 실패일 때")
     @WithMockUser
     void login2() throws Exception {
+        // ISSUE: Body가 비어서 옴. (테스트환경에서만)
         LoginRequestDto testDto = ReflectionUtils.newInstance(LoginRequestDto.class);
         ReflectionTestUtils.setField(testDto, "loginId", "testUser1");
         ReflectionTestUtils.setField(testDto, "password", "12321532");

--- a/src/test/java/store/cookshoong/www/cookshoongauth/controller/AuthControllerTest.java
+++ b/src/test/java/store/cookshoong/www/cookshoongauth/controller/AuthControllerTest.java
@@ -1,0 +1,111 @@
+package store.cookshoong.www.cookshoongauth.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Constructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.util.UriComponentsBuilder;
+import store.cookshoong.www.cookshoongauth.adapter.ApiAdapter;
+import store.cookshoong.www.cookshoongauth.config.SecurityConfig;
+import store.cookshoong.www.cookshoongauth.jwt.JsonWebTokenProvider;
+import store.cookshoong.www.cookshoongauth.jwt.JwtProperties;
+import store.cookshoong.www.cookshoongauth.model.request.LoginRequestDto;
+import store.cookshoong.www.cookshoongauth.model.response.AuthenticationResponseDto;
+import store.cookshoong.www.cookshoongauth.model.response.LoginSuccessResponseDto;
+import store.cookshoong.www.cookshoongauth.model.vo.AccountInfo;
+import store.cookshoong.www.cookshoongauth.service.AuthService;
+
+/**
+ * 엔드포인트 동작 확인.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.15
+ */
+@WebMvcTest(AuthController.class)
+@Import({JwtProperties.class, SecurityConfig.class})
+class AuthControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    AuthService authService;
+
+    @Test
+    @DisplayName("로그인 - 검증 성공일 때")
+    @WithMockUser
+    void login() throws Exception {
+        // ISSUE: Body가 비어서 옴. (테스트환경에서만)
+        LoginRequestDto testDto = ReflectionUtils.newInstance(LoginRequestDto.class);
+        ReflectionTestUtils.setField(testDto, "loginId", "testUser1");
+        ReflectionTestUtils.setField(testDto, "password", "1234");
+
+        LoginSuccessResponseDto expect = new LoginSuccessResponseDto("accessToken", "refreshToken");
+        AccountInfo testAccountInfo = mock(AccountInfo.class);
+        doReturn(testAccountInfo).when(authService).executeAuthentication(testDto);
+        doReturn(expect).when(authService).issueTokens(testAccountInfo);
+
+        RequestBuilder request = MockMvcRequestBuilders.post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(testDto));
+
+        mockMvc.perform(request)
+            .andExpect(status().isOk())
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그인 - 검증 실패일 때")
+    @WithMockUser
+    void login2() throws Exception {
+        LoginRequestDto testDto = ReflectionUtils.newInstance(LoginRequestDto.class);
+        ReflectionTestUtils.setField(testDto, "loginId", "testUser1");
+        ReflectionTestUtils.setField(testDto, "password", "12321532");
+
+        doThrow(HttpClientErrorException.class).when(authService).executeAuthentication(any(LoginRequestDto.class));
+
+        RequestBuilder request = MockMvcRequestBuilders.post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(testDto));
+
+        mockMvc.perform(request)
+            .andExpect(status().isNotFound())
+            .andDo(print());
+    }
+}

--- a/src/test/java/store/cookshoong/www/cookshoongauth/learning/BCryptPasswordEncoderTests.java
+++ b/src/test/java/store/cookshoong/www/cookshoongauth/learning/BCryptPasswordEncoderTests.java
@@ -1,0 +1,51 @@
+package store.cookshoong.www.cookshoongauth.learning;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/**
+ * BCryptPasswordEncoder 의 동작을 알아보기 위한 테스트.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.14
+ */
+class BCryptPasswordEncoderTests {
+    @Test
+    @DisplayName("같은 평문에 대해서는 어떤 BCryptPasswordEncoder 객체를 쓰던 검증이 가능하다..")
+    void test1() {
+        BCryptPasswordEncoder aEncoder = new BCryptPasswordEncoder();
+        BCryptPasswordEncoder bEncoder = new BCryptPasswordEncoder();
+
+        assertTrue(bEncoder.matches("1234", aEncoder.encode("1234")));
+    }
+
+    @Test
+    @DisplayName("같은 평문이라도 다른 BCryptPasswordEncoder 객체에선 서로 다른 해시값을 가진다.")
+    void test2() {
+        BCryptPasswordEncoder aEncoder = new BCryptPasswordEncoder();
+        BCryptPasswordEncoder bEncoder = new BCryptPasswordEncoder();
+
+        String password = "1234";
+        assertThat(aEncoder.encode(password), is(not(equalTo(bEncoder.encode(password)))));
+    }
+
+    @Test
+    @DisplayName("평문을 알아야 BCryptoEncoder 로 비밀번호가 일치하는 지 알 수 있다.")
+    void test3() {
+        BCryptPasswordEncoder aEncoder = new BCryptPasswordEncoder();
+
+        String password = "1234";
+        String encodedPassword = "$2a$10$30tERj8td6hFOOVnsYjJn.YF7rcdh53Opow6B//OUgviRfdVqFi0W";
+
+        assertTrue(aEncoder.matches(password, encodedPassword));
+        assertFalse(aEncoder.matches(encodedPassword, encodedPassword));
+    }
+}

--- a/src/test/java/store/cookshoong/www/cookshoongauth/learning/UriComponentBuilderTests.java
+++ b/src/test/java/store/cookshoong/www/cookshoongauth/learning/UriComponentBuilderTests.java
@@ -1,0 +1,103 @@
+package store.cookshoong.www.cookshoongauth.learning;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * UriComponentsBuilder 의 동작을 알아보기 위한 테스트.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.15
+ */
+class UriComponentBuilderTests {
+
+    @Test
+    @DisplayName("path 만을 사용하면 slash가 붙지 않는다.")
+    void test1() {
+        String expect = "http://localhost:8080/apiaccounts{loginId}auth";
+
+        String actual = UriComponentsBuilder.fromUriString("http://localhost:8080")
+            .path("api")
+            .path("accounts")
+            .path("{loginId}")
+            .path("auth")
+            .build()
+            .toString();
+
+        System.out.println(actual);
+        assertThat(actual, is(expect));
+    }
+    @Test
+    @DisplayName("pathSegment로 값을 넣어주면 앞뒤로 /가 붙는다.")
+    void test2() {
+        String expect = "http://localhost:8080/api/accounts/{loginId}/auth";
+
+        String actual = UriComponentsBuilder.fromUriString("http://localhost:8080")
+            .path("api")
+            .pathSegment("accounts")
+            .path("{loginId}")
+            .pathSegment("auth")
+            .build()
+            .toString();
+
+        System.out.println(actual);
+        assertThat(actual, is(expect));
+    }
+
+    @Test
+    @DisplayName("pathSegment가 앞뒤로 /를 넣는다고 해서 중복되는 것은 아니다.")
+    void test3() {
+        String expect = "http://localhost:8080/api/accounts/{loginId}/auth";
+
+        String actual = UriComponentsBuilder.fromUriString("http://localhost:8080")
+            .pathSegment("api")
+            .pathSegment("accounts")
+            .pathSegment("{loginId}")
+            .pathSegment("auth")
+            .build()
+            .toString();
+
+        System.out.println(actual);
+        assertThat(actual, is(expect));
+    }
+
+    @Test
+    @DisplayName("pathSegment도 뒤에 path가 유효하지 않으면(빈값) /를 넣지 않는다.")
+    void test4() {
+        String expect = "http://localhost:8080/api/accounts/{loginId}/auth";
+
+        String actual = UriComponentsBuilder.fromUriString("http://localhost:8080")
+            .pathSegment("api")
+            .pathSegment("accounts")
+            .pathSegment("{loginId}")
+            .pathSegment("auth")
+            .pathSegment("")
+            .build()
+            .toString();
+
+        System.out.println(actual);
+        assertThat(actual, is(expect));
+    }
+
+    @Test
+    @DisplayName("pathSegment도 뒤에 path가 유효하지 않으면(공백) /를 넣지 않는다.")
+    void test5() {
+        String expect = "http://localhost:8080/api/accounts/{loginId}/auth";
+
+        String actual = UriComponentsBuilder.fromUriString("http://localhost:8080")
+            .pathSegment("api")
+            .pathSegment("accounts")
+            .pathSegment("{loginId}")
+            .pathSegment("auth")
+            .pathSegment("            ")
+            .build()
+            .toString();
+
+        System.out.println(actual);
+        assertThat(actual, is(expect));
+    }
+}

--- a/src/test/java/store/cookshoong/www/cookshoongauth/util/JwtFactoryTest.java
+++ b/src/test/java/store/cookshoong/www/cookshoongauth/util/JwtFactoryTest.java
@@ -1,0 +1,45 @@
+package store.cookshoong.www.cookshoongauth.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.jsonwebtoken.security.WeakKeyException;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Jwt 생성결과를 확인하기 위한 테스트.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.07.14
+ */
+class JwtFactoryTest {
+    @Test
+    @DisplayName("Jwt는 헤더, 페이로드, 서명 세 부분으로 나뉘고 .으로 구분된다.")
+    void test1() {
+        String encodedJwt = JwtFactory.createToken(Map.of(), Map.of("accountId", 1L),
+            "TempTokenMustBeLargerThan256Bit!!", 10);
+
+        assertThat(encodedJwt.split("\\.").length, is(3));
+    }
+
+    @Test
+    @DisplayName("Secret 을 키로 만들 때 암호화 알고리즘이 사용된다." +
+        " 각 암호화 알고리즘에 필요한 Secret 의 길이가 있으며 HMAC-SHA 알고리즘에서는 256 bit가 넘어야 한다. ")
+    void test2() {
+        assertDoesNotThrow(() -> JwtFactory.createToken(Map.of(), Map.of("accountId", 1L),
+            "TokenSecretMustBeLargerThan256Bit!!", 10));
+    }
+
+    @Test
+    @DisplayName("HMAC-SHA 알고리즘은 256bit 가 넘어야 한다. ")
+    void test3() {
+        assertThrows(WeakKeyException.class,
+            () -> JwtFactory.createToken(Map.of(), Map.of("accountId", 1L),
+                "ItislessThan256Bit", 10));
+    }
+}


### PR DESCRIPTION
로그인 성공시 액세스토큰과 리프레쉬토큰을 응답으로 내보냅니다.
로그인 실패시 404를 보내며 빈 값을 응답합니다.
추후 SKM을 적용하여 Secret을 관리할 예정입니다.