### PR TITLE
refactor: 💡 수정 토큰 만료기한 조정

### DIFF
--- a/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JwtConfig.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JwtConfig.java
@@ -31,7 +31,7 @@ public class JwtConfig {
     public JwtProperties jwtProperties(@Value("${cookshoong.skm.keyid.jwt}") String jwtKeyid,
                                        SKMService skmService) throws JsonProcessingException {
         JwtSecret jwtSecret = skmService.fetchSecrets(jwtKeyid, JwtSecret.class);
-        JwtTtl jwtTtl = new JwtTtl(Times.HOUR, 24 * Times.HOUR);
+        JwtTtl jwtTtl = new JwtTtl(30 * Times.MINUTE,  2 * Times.HOUR);
         return new JwtProperties(jwtSecret, jwtTtl);
     }
 }


### PR DESCRIPTION
세션 유지시간을 감안하여 액세스 토큰의 만료시간을 30분으로 잡았고
서비스 유지 시간을 고려해서 리프레쉬 토큰의 만료시간을 2시간으로 축소하였습니다.