### PR TITLE
refactor: 💡 추가 에러 로깅 Aspect 작성 및 액세스 토큰 시간 조정

### DIFF
--- a/src/main/java/store/cookshoong/www/cookshoongauth/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/advice/ControllerExceptionAdvice.java
@@ -28,8 +28,14 @@ public class ControllerExceptionAdvice {
     @ExceptionHandler({LoginValidationException.class, RefreshTokenValidationException.class,
         InvalidTokenTypeException.class, MissingRequestHeaderException.class, InvalidAccountCodeException.class,
         MissingRefreshTokenException.class})
-    public ResponseEntity<Void> badRequest() {
+    public ResponseEntity<Void> badRequest(Exception e) {
         return ResponseEntity.badRequest()
+            .build();
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Void> handleInternalServerError(Exception e) {
+        return ResponseEntity.internalServerError()
             .build();
     }
 }

--- a/src/main/java/store/cookshoong/www/cookshoongauth/aop/ErrorLoggingAspect.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/aop/ErrorLoggingAspect.java
@@ -1,0 +1,30 @@
+package store.cookshoong.www.cookshoongauth.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+/**
+ * 서버에서 처리된 예외들을 로깅하기 위한 Aspect.
+ *
+ * @author koesnam (추만석)
+ * @since 2023.08.22
+ */
+@Slf4j
+@Aspect
+public class ErrorLoggingAspect {
+    /**
+     * 에러를 로깅하기 위한 어드바이스.
+     *
+     * @param joinPoint the join point
+     */
+    @Before("@within(org.springframework.web.bind.annotation.ControllerAdvice)")
+    public void logError(JoinPoint joinPoint) {
+        if (joinPoint.getArgs()[0] instanceof Exception) {
+            Exception exception = (Exception) joinPoint.getArgs()[0];
+            log.warn("처리 완료된 예외 : {} \n --> {}", exception.getMessage(), ExceptionUtils.getStackTrace(exception));
+        }
+    }
+}

--- a/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JwtConfig.java
+++ b/src/main/java/store/cookshoong/www/cookshoongauth/jwt/JwtConfig.java
@@ -31,7 +31,7 @@ public class JwtConfig {
     public JwtProperties jwtProperties(@Value("${cookshoong.skm.keyid.jwt}") String jwtKeyid,
                                        SKMService skmService) throws JsonProcessingException {
         JwtSecret jwtSecret = skmService.fetchSecrets(jwtKeyid, JwtSecret.class);
-        JwtTtl jwtTtl = new JwtTtl(5 * Times.MINUTE + 30 * Times.SECOND,  2 * Times.HOUR);
+        JwtTtl jwtTtl = new JwtTtl(30 * Times.MINUTE,  2 * Times.HOUR);
         return new JwtProperties(jwtSecret, jwtTtl);
 
     }

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,5 +1,5 @@
 spring.application.name=AUTH
-
+logging.level.root=WARN
 api.gateway-uri=http://125.6.38.108:8100
 
 management.endpoint.shutdown.enabled=true

--- a/src/main/resources/application-prod2.properties
+++ b/src/main/resources/application-prod2.properties
@@ -1,5 +1,5 @@
 spring.application.name=AUTH
-
+logging.level.root=WARN
 api.gateway-uri=http://125.6.38.108:8100
 
 management.endpoint.shutdown.enabled=true


### PR DESCRIPTION
프론트와 백엔드 서버에서 사용되는 Logging Aspect를 인증서버에도 적용시켰습니다. 유레카 헬스체크 로그를 피하기위해 로깅 레벨을 WARN로 올렸습니다. 토큰 재발급 테스트를 위해 조정했던 액세스 토큰의 만료기간을 다시 30분으로 올렸습니다.